### PR TITLE
Public anonymous grafana

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+## Public metrics
+
+Public metrics are hosted at: https://grafana.prod.discovery.etcd.io/d/uiLwPyPWk/discoveryserver?orgId=2
+
 ## discovery.etcd.io Kubernetes Configurations
 
 This repo contains the code to provision the infrastructure and the Kubernetes configurations to operate the public discovery.etcd.io service.

--- a/kubernetes/helm/prometheus/deploy.sh
+++ b/kubernetes/helm/prometheus/deploy.sh
@@ -1,0 +1,9 @@
+env=$1
+version="8.3.3"
+
+helm3 upgrade prometheus-operator stable/prometheus-operator \
+        --install --debug --atomic \
+        --timeout 2m \
+        --namespace prometheus \
+        --version $version \
+        --values values.yaml,$env.values.yaml

--- a/kubernetes/helm/prometheus/dev.values.yaml
+++ b/kubernetes/helm/prometheus/dev.values.yaml
@@ -1,0 +1,8 @@
+grafana:
+  ingress:
+    hosts:
+      - grafana.dev.discovery.etcd.io
+    tls:
+    - hosts:
+      - grafana.dev.discovery.etcd.io
+      secretName: tls-grafana-cert

--- a/kubernetes/helm/prometheus/prod.values.yaml
+++ b/kubernetes/helm/prometheus/prod.values.yaml
@@ -1,0 +1,8 @@
+grafana:
+  ingress:
+    hosts:
+      - grafana.prod.discovery.etcd.io
+    tls:
+    - hosts:
+      - grafana.prod.discovery.etcd.io
+      secretName: tls-grafana-cert

--- a/kubernetes/helm/prometheus/values.yaml
+++ b/kubernetes/helm/prometheus/values.yaml
@@ -12,9 +12,26 @@ alertmanager:
 ## Using default values from https://github.com/helm/charts/blob/master/stable/grafana/values.yaml
 ##
 grafana:
-  persistence:
-    type: pvc
+  grafana.ini:
+    auth.anonymous:
+      enabled: true
+      org_name: Anonymous
+      org_role: Viewer
+  ingress:
     enabled: true
+    annotations: 
+      cert-manager.io/cluster-issuer: letsencrypt
+      kubernetes.io/ingress.class: nginx
+      kubernetes.io/tls-acme: "true"
+    hosts:
+      - grafana.<ENV>.discovery.etcd.io
+    tls:
+    - hosts:
+      - grafana.<ENV>.discovery.etcd.io
+      secretName: grafana-cert
+  persistence:
+    enabled: true
+    type: pvc
     storageClassName: standard
     accessModes:
       - ReadWriteOnce
@@ -36,3 +53,4 @@ prometheus:
           resources:
             requests:
               storage: 20Gi
+


### PR DESCRIPTION
- Hosts grafana publicly, for dev and prod. 
- Allows anon users to view dashboards

Deployed to dev only.