### PR TITLE
Comment node pool to scale down to 0 nodes

### DIFF
--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -30,16 +30,16 @@ module "gke" {
   subnetwork = module.vpc.gke_subnetwork
 
   gke_nodepools = [
-    {
-      auto_repair = true
-      auto_upgrade = false
-      min_node_count = 1
-      max_node_count = 10
-      machine_type = "n1-standard-2"
-      disk_size_gb = "50"
-      preemptible = false
-      version = "1.14.6-gke.1"
-    },
+//    {
+//      auto_repair = true
+//      auto_upgrade = false
+//      min_node_count = 1
+//      max_node_count = 10
+//      machine_type = "n1-standard-2"
+//      disk_size_gb = "50"
+//      preemptible = false
+//      version = "1.14.6-gke.1"
+//    },
   ]
 }
 

--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -30,16 +30,17 @@ module "gke" {
   subnetwork = module.vpc.gke_subnetwork
 
   gke_nodepools = [
-//    {
-//      auto_repair = true
-//      auto_upgrade = false
-//      min_node_count = 1
-//      max_node_count = 10
-//      machine_type = "n1-standard-2"
-//      disk_size_gb = "50"
-//      preemptible = false
-//      version = "1.14.6-gke.1"
-//    },
+    #Scaling down dev cluster to 0 while not needed
+    /*{
+        auto_repair = true
+        auto_upgrade = false
+        min_node_count = 1
+        max_node_count = 10
+        machine_type = "n1-standard-2"
+        disk_size_gb = "50"
+        preemptible = false
+        version = "1.14.6-gke.1"
+      },*/
   ]
 }
 


### PR DESCRIPTION
We are scaling down the node for the `etcd-io-dev` as it's not been used.
This change has been applied.