### PR TITLE
Upgrade velero to latest version

### DIFF
--- a/kubernetes/helm/etcd/README.md
+++ b/kubernetes/helm/etcd/README.md
@@ -7,7 +7,7 @@ https://artifacthub.io/packages/helm/bitnami/etcd
 helm repo add bitnami https://charts.bitnami.com/bitnami
 helm repo update
 # Install
-helm install etcd bitnami/etcd --version 6.13.4 --namespace discoveryserver -f values.yaml
+helm install etcd bitnami/etcd --version 8.2.2 --namespace discoveryserver -f values.yaml
 # Upgrade
-helm upgrade etcd bitnami/etcd --version 6.13.4 --namespace discoveryserver --debug -f values.yaml
+helm upgrade etcd bitnami/etcd --version 8.2.2 --namespace discoveryserver --debug -f values.yaml
 ```

--- a/kubernetes/helm/velero/README.md
+++ b/kubernetes/helm/velero/README.md
@@ -3,7 +3,7 @@
 Get the latest version of the velero helm chart [here](https://github.com/vmware-tanzu/helm-charts/tree/master/charts/velero).
 
 ```console
-$ export VERSION=2.8.2
+$ export VERSION=2.30.2
 ```
 
 ## Installing the Chart

--- a/kubernetes/helm/velero/deploy.sh
+++ b/kubernetes/helm/velero/deploy.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 env=$1
-version=2.29.4
+version=2.30.2
 
 helm upgrade velero vmware-tanzu/velero --install --create-namespace --namespace velero -f ${env}.values.yaml --version ${version} --atomic --debug

--- a/kubernetes/helm/velero/dev.values.yaml
+++ b/kubernetes/helm/velero/dev.values.yaml
@@ -8,7 +8,7 @@ resources: {}
 
 initContainers:
   - name: velero-plugin-for-gcp
-    image: velero/velero-plugin-for-gcp:v1.4.1
+    image: velero/velero-plugin-for-gcp:v1.5.0
     imagePullPolicy: IfNotPresent
     volumeMounts:
       - mountPath: /target
@@ -17,6 +17,7 @@ initContainers:
 configuration:
   provider: gcp
   backupStorageLocation:
+    default: true
     name: gcp
     bucket: etcd-io-dev-backups
     prefix: velero

--- a/kubernetes/helm/velero/prod.values.yaml
+++ b/kubernetes/helm/velero/prod.values.yaml
@@ -8,7 +8,7 @@ resources: {}
 
 initContainers:
   - name: velero-plugin-for-gcp
-    image: velero/velero-plugin-for-gcp:v1.4.1
+    image: velero/velero-plugin-for-gcp:v1.5.0
     imagePullPolicy: IfNotPresent
     volumeMounts:
       - mountPath: /target
@@ -17,6 +17,7 @@ initContainers:
 configuration:
   provider: gcp
   backupStorageLocation:
+    default: true
     name: gcp
     bucket: etcd-io-backups
     prefix: velero


### PR DESCRIPTION
Backup test:
```
velero backup describe velero-gcp-test-upgrade2
Name:         velero-gcp-test-upgrade2
Namespace:    velero
Labels:       velero.io/storage-location=gcp
Annotations:  velero.io/source-cluster-k8s-gitversion=v1.21.12-gke.1700
              velero.io/source-cluster-k8s-major-version=1
              velero.io/source-cluster-k8s-minor-version=21

Phase:  Completed

Errors:    0
Warnings:  0

Namespaces:
  Included:  *
  Excluded:  <none>

Resources:
  Included:        *
  Excluded:        <none>
  Cluster-scoped:  auto

Label selector:  <none>

Storage Location:  gcp

Velero-Native Snapshot PVs:  auto

TTL:  720h0m0s

Hooks:  <none>

Backup Format Version:  1.1.0

Started:    2022-08-09 11:54:19 -0500 CDT
Completed:  2022-08-09 11:54:51 -0500 CDT

Expiration:  2022-09-08 11:54:17 -0500 CDT

Total items to be backed up:  1443
Items backed up:              1443

Velero-Native Snapshots:  10 of 10 snapshots completed successfully (specify --details for more information)
```