### PR TITLE
Upgrade terraform modules

### DIFF
--- a/terraform/dev/config.tfvars
+++ b/terraform/dev/config.tfvars
@@ -7,7 +7,7 @@ network_prefix = "10.128"
 
 # gke values
 location = "us-central1"
-min_master_version = "1.17.9-gke.6300"
+min_master_version = "1.21.12-gke.2200"
 master_ipv4_cidr_block = "172.31.0.0/28"
 
 gke_master_authorized_networks = [

--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -11,10 +11,10 @@ provider "google-beta" {
 terraform {
   required_providers {
     google = {
-      version = "~> 2.16.0"
+      version = "~> 4.32.0"
     }
     google-beta = {
-      version = "~> 3.73.0"
+      version = "~> 4.32.0"
     }
   }
 }
@@ -27,7 +27,7 @@ terraform {
 }
 
 module "gke" {
-  source = "git::git@github.com:cloudkite-io/terraform-modules.git//modules/gcp/gke?ref=v0.0.4"
+  source = "git::git@github.com:cloudkite-io/terraform-modules.git//modules/gcp/gke?ref=v0.1.3"
   environment = var.environment
   gke_pods_secondary_range_name = module.vpc.gke_subnetwork_secondary_range_name_services
   gke_services_secondary_range_name = module.vpc.gke_subnetwork_secondary_range_name_pods
@@ -39,23 +39,26 @@ module "gke" {
   region = var.region
   subnetwork = module.vpc.gke_subnetwork
 
-  gke_nodepools = [
+  gke_nodepools = {
     #Scaling down dev cluster to 0 while not needed
-    # {
-    #     auto_repair = true
-    #     auto_upgrade = false
-    #     min_node_count = 1
-    #     max_node_count = 10
-    #     machine_type = "n1-standard-2"
-    #     disk_size_gb = "50"
-    #     preemptible = false
-    #     version = var.min_master_version
-    #   },
-  ]
+    dev-gke-pool-0 = {
+      auto_repair = true
+      auto_upgrade = false
+      min_node_count = 1
+      max_node_count = 10
+      max_pods_per_node = 110
+      machine_type = "n1-standard-2"
+      disk_size_gb = "50"
+      disk_type = "pd-standard"
+      preemptible = false
+      version = var.min_master_version
+      labels = {}
+    } ,
+  }
 }
 
 module "vpc" {
-  source = "git::git@github.com:cloudkite-io/terraform-modules.git//modules/gcp/vpc?ref=v0.0.4"
+  source = "git::git@github.com:cloudkite-io/terraform-modules.git//modules/gcp/vpc?ref=v0.1.3"
   environment = var.environment
   network-prefix = var.network_prefix
   project = var.project
@@ -63,10 +66,11 @@ module "vpc" {
 }
 
 module "velero" {
-  source = "git::git@github.com:cloudkite-io/terraform-modules.git//modules/gcp/velero?ref=v0.0.4"
+  source = "git::git@github.com:cloudkite-io/terraform-modules.git//modules/gcp/velero?ref=v0.1.3"
 
   backups_bucket_location = "US"
   backups_bucket_name = "${var.project}-backups"
   project = var.project
   service_account_name = "${module.gke.name}-velero-sa"
+  backup_project          = var.project
 }


### PR DESCRIPTION
- Upgrades google and google-beta providers.
- Converts nodepools to a map which gives more flexibility if we want to add/remove extra pools.

The Terraform plan have been applied.

Note: The code [here](https://github.com/etcd-io/discovery.etcd.io/pull/63/files#diff-1c45f90b87a9db6b9e68d9a5525d0a664f3c0120562b55f11617a4162fdbf692R33-R34)
```
gke_pods_secondary_range_name = module.vpc.gke_subnetwork_secondary_range_name_pods
gke_services_secondary_range_name = module.vpc.gke_subnetwork_secondary_range_name_pods
```
Is using the same IP range for pods and services. This was introduced by a bug ([see here](https://github.com/cloudkite-io/terraform-modules/pull/21/files)) in an earlier version of the `gke` TF module. The fix will require a cluster recreation and it is going to be in a separate PR.
