### PR TITLE
Point etcd and discoveryserver charts at live registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,14 +33,14 @@ Next step is to apply Terraform for the chosen environment. To ensure that it is
 and follow the [README](https://github.com/etcd-io/discovery.etcd.io/blob/master/terraform/README.md) instructions.
 
 #### Manual Step
-Once dev and prod infrastructure is built, it is required to update IAM policies of `artifacts.<dev-project>.appspot.com` GCS bucket adding both dev and prod gke_service_accounts
-as members with the role `roles/storage.objectViewer`. Only after it, clusters in both environments will be able to pull images from gcr.
+The discoveryserver image is published to Artifact Registry in the `etcd-io-dev` project
+(`us-docker.pkg.dev/etcd-io-dev/discoveryserver`), as gcr.io / Container Registry was shut down by Google in 2025.
+For clusters to pull it, the gke_service_accounts of both environments must have the role
+`roles/artifactregistry.reader` on that repository (prod pulls cross-project from `etcd-io-dev`).
 
-Gsutil command to update the IAM policy:
+gcloud command to grant the role:
 
-`gsutil iam ch serviceAccount:[SERVICE_ACCOUNT_EMAIL]:roles/storage.objectViewer gs://artifacts.<dev-project>.appspot.com`
-
-Note: if you get an error that the `artifacts.<dev-project>.appspot.com` does not exit, push an image and it will be created.
+`gcloud artifacts repositories add-iam-policy-binding discoveryserver --location=us --project=etcd-io-dev --member="serviceAccount:[SERVICE_ACCOUNT_EMAIL]" --role=roles/artifactregistry.reader`
 
 After applying terraform, a GKE cluster will be up and running in the VPC created. Now the cluster is ready to get deployments.
 

--- a/kubernetes/helm/discoveryserver/dev.values.yaml
+++ b/kubernetes/helm/discoveryserver/dev.values.yaml
@@ -4,9 +4,9 @@
 
 replicaCount: 5
 
-# Images are built using cloudbuild and published to GCP project etcd-io-dev
+# Built by cloudbuild, published to Artifact Registry in etcd-io-dev (gcr.io shut down in 2025); cloudbuild.dev.yaml overrides image.tag with COMMIT_SHA at deploy time.
 image:
-  repository: gcr.io/etcd-io-dev/discoveryserver
+  repository: us-docker.pkg.dev/etcd-io-dev/discoveryserver/discoveryserver
   tag: latest
   pullPolicy: IfNotPresent
 

--- a/kubernetes/helm/discoveryserver/prod.values.yaml
+++ b/kubernetes/helm/discoveryserver/prod.values.yaml
@@ -4,10 +4,11 @@
 
 replicaCount: 5
 
-# Images are built using cloudbuild and published to GCP project etcd-io-dev
+# Built by cloudbuild, published to Artifact Registry in etcd-io-dev (gcr.io shut down in 2025); needs artifactregistry.reader on the prod node SA, see README.
+# cloudbuild.prod.yaml overrides image.tag with the app COMMIT_SHA at deploy time.
 image:
-  repository: gcr.io/etcd-io-dev/discoveryserver
-  tag: latest
+  repository: us-docker.pkg.dev/etcd-io-dev/discoveryserver/discoveryserver
+  tag: 48dabf80254960bf942cd81fe184f541b4c2f8fd
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/kubernetes/helm/etcd/values.yaml
+++ b/kubernetes/helm/etcd/values.yaml
@@ -1,5 +1,11 @@
 replicaCount: 5
 
+# bitnami removed versioned tags in 2025; unsupported mirror lives at bitnamilegacy. TODO: move to official etcd image.
+image:
+  registry: docker.io
+  repository: bitnamilegacy/etcd
+  tag: 3.5.4-debian-11-r3
+
 auth:
   rbac:
     create: false


### PR DESCRIPTION
## After GCR/Bitnami shutdown.

## Summary

The public discovery.etcd.io service was fully down (ImagePullBackOff on all pods, prod-gke / project etcd-io, namespace discoveryserver).
Service is now restored and verified end-to-end. All fixes were applied live under emergency; they are not yet committed to git and need follow-up to be durable.

## Root cause

Two independent "dead registry" failures, both exposed when the GKE nodes recycled ~May 29 2026 (which wiped the locally-cached images the pods had been running on for years):

  1. discoveryserver — image hosted on Google Container Registry (gcr.io/etcd-io-dev/discoveryserver), which Google permanently shut down in 2025. The repo is gone (NAME_UNKNOWN).
  2. etcd — image docker.io/bitnami/etcd:3.5.4-debian-11-r3; Bitnami removed versioned/legacy tags from docker.io/bitnami/* in 2025.

(Architecture note: prod pulls the discoveryserver image cross-project from the etcd-io-dev project — only cloudbuild.dev.yaml builds the image; cloudbuild.prod.yaml only runs the helm deploy.)

## What we did (emergency mitigation)

###  etcd (datastore):
  - Switched the StatefulSet image to the surviving mirror: docker.io/bitnamilegacy/etcd:3.5.4-debian-11-r3 (same version/content).
  - Rolled pods one at a time, deleting the stuck old-image pods so quorum re-formed cleanly. PVC data preserved; members rejoined the existing cluster, no restore needed.

### discoveryserver (app):
  - Rebuilt the image from source (etcd-io/discoveryserver, master 418ab9f) and pushed to Artifact Registry:
  us-docker.pkg.dev/etcd-io-dev/discoveryserver/discoveryserver:48dabf80254960bf942cd81fe184f541b4c2f8fd.
  - Granted the prod node SA (prod-gke-sa@etcd-io.iam.gserviceaccount.com) roles/artifactregistry.reader on that dev-project AR repo (needed for
  the cross-project pull).
  - Pointed the Deployment at the new image.

## Verification:
  - etcd: 5/5 members started, all endpoints healthy, quorum OK.
  - discoveryserver: 5/5 1/1 Running, /health 200, connected to all 5 etcd members.
  - End-to-end: GET /new minted a real token (https://discovery.etcd.io/1e52da17…), confirming the etcd write path.

  What we have now (current state / risks)

  - ✅ Service fully functional.
  - ⚠️  etcd is running on bitnamilegacy — an archived, unsupported image (no future updates or CVE patches).
  - ✅ A clean discoveryserver image now exists in Artifact Registry.

## Possible plan

  Phase 1 — Persist the emergency fixes (done).
  - discovery.etcd.io repo:
    - kubernetes/helm/etcd/values.yaml → add image override to bitnamilegacy/etcd:3.5.4-debian-11-r3.
    - kubernetes/helm/discoveryserver/{dev,prod}.values.yaml → image.repository to the AR path.
    - README.md → replace the old "Manual Step" (gcr artifacts-bucket IAM) with the new AR-reader IAM note.
  - etcd-io/discoveryserver repo:
    - cloudbuild.dev.yaml → build/push to Artifact Registry instead of gcr.io (branch cloudbuild-dev-push-to-artifact-registry already started).

  Phase 2 — Get off unsupported images (etcd, deliberate follow-up):
  - The bitnami chart can't simply swap to an official etcd image. Its StatefulSet is built around bitnami wrapper scripts (entrypoint, preStop, probes, /opt/bitnami + /bitnami/etcd/data paths, runAsUser 1001). The official image ships only the etcd/etcdctl binaries.
  - Migrate etcd to a plain StatefulSet on the official image (quay.io/coreos/etcd, patched to v3.5.x ≥ current, or registry.k8s.io/etcd). On-disk data is standard etcd v3 and reusable, so existing PVCs can be kept (no dump/restore) with care.
  - Test in dev first; take an etcdctl snapshot save before touching prod; use a maintenance window.